### PR TITLE
refine libusb port

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -244,25 +244,25 @@ void ANT::run()
     {
         // read more bytes from the device
         uint8_t byte;
-	int rc = rawRead(&byte, 1);
-	if (rc > 0)
-	  receiveByte(byte);
+        int rc = rawRead(&byte, 1);
+        if (rc > 0)
+          receiveByte(byte);
         else {
 #if defined GC_HAVE_LIBUSB
-	  if (rc == LIBUSB_ERROR_NO_DEVICE) {
-	    // Can happen when the USB stick is pulled.
-	    stop();
-	  } else if (rc == LIBUSB_ERROR_PIPE) {
-	    // Endpoint halted.
-	    restart();
-	  } else {
-	    // Typically a timeout (error -110).
-	    msleep(5);
-	  }
+          if (rc == LIBUSB_ERROR_NO_DEVICE) {
+            // Can happen when the USB stick is pulled.
+            stop();
+          } else if (rc == LIBUSB_ERROR_PIPE) {
+            // Endpoint halted.
+            restart();
+          } else {
+            // Typically a timeout (error -110).
+            msleep(5);
+          }
 #else
           msleep(5);
 #endif
-	}
+        }
         //----------------------------------------------------------------------
         // LISTEN TO CONTROLLER FOR COMMANDS
         //----------------------------------------------------------------------

--- a/src/gcconfig.pri.in
+++ b/src/gcconfig.pri.in
@@ -156,18 +156,18 @@
 #     http://sourceforge.net/projects/libusb-win32/files/libusb-win32-releases/0.1.12.2/
 # You may override the INCLUDE and LIB files if you like.
 # You *must* define LIBUSB_INSTALL to use this feature and ensure that the LIBUSB1_*
-# definitons are commented out.
+# definitions are commented out.
 #LIBUSB_INSTALL = /usr/local
 #LIBUSB_INCLUDE = 
-#LIBUSB_LIBS    =  -lusb1.0
+#LIBUSB_LIBS    = 
 
 # If you want to use version 1.0.18+, then ensure that the LIBUSB_*
 # definitions above are commented out and the LIBUSB1_INSTALL is
 # uncommented.
 #
-#LIBUSB1_INSTALL = /usr
-#LIBUSB1_INCLUDE = /usr/include
-#LIBUSB1_LIBS = -lusb-1.0
+#LIBUSB1_INSTALL = /usr/local
+#LIBUSB1_INCLUDE = 
+#LIBUSB1_LIBS = 
 
 # if you want video playback on training mode then
 # download and install vlc (videolan) from

--- a/src/src.pro
+++ b/src/src.pro
@@ -142,8 +142,8 @@ CONFIG(debug, debug|release) {
 !isEmpty( LIBUSB1_INSTALL ) {
     isEmpty( LIBUSB1_INCLUDE ) { LIBUSB1_INCLUDE = $${LIBUSB1_INSTALL}/include }
     isEmpty( LIBUSB1_LIBS )    {
-        unix  { LIBUSB1_LIBS = -lusb-1.0 }
-        win32 { LIBUSB1_LIBS = -lusb-1.0 }
+        unix  { LIBUSB1_LIBS = $${LIBUSB1_INSTALL}/lib/libusb-1.0.a -ludev }
+        win32 { LIBUSB1_LIBS = $${LIBUSB1_INSTALL}/lib/libusb-1.0.a -ludev }
     }
     INCLUDEPATH += $${LIBUSB1_INCLUDE}
     LIBS        += $${LIBUSB1_LIBS}
@@ -295,6 +295,9 @@ SOURCES +=  ../qtsolutions/qwtcurve/qwt_plot_gapped_curve.cpp
     DEPENDPATH += $$HTPATH
 
     DEFINES += GC_WANT_HTTP
+
+    HEADERS +=  APIWebService.h
+    SOURCES +=  APIWebService.cpp
 
     HEADERS +=  $$HTPATH/httpglobal.h \
                 $$HTPATH/httplistener.h \


### PR DESCRIPTION
Several improvements
1. Replace tabs with spaces like the rest of ANT.cpp is indented.
2. Clean up LIBUSB definitions in gcconfig.pri.in so they look like the previous ones.
3. Clean up LIBUSB1 definitions so they look like LIBUSB.
4. Statically link to `libusb-1.0.a like the old libusb-0.1 was linked to.
5. Add APIWebService back in to not break builds when HTPATH is enabled.

I hope you'll accept these, merge them in, then rebase and squash the the changes into one commit for your pull request into GC (like Mark requested). Maybe these changes will show someone else is reviewing and helping out and improve the odds for merging into mainline. I'll continue to look over the code and see if anything else can be changed to make the odds even better.

While they aren't code changes, I still compiled them in and tested on my bike trainer.
