### PR TITLE
fix builds for libusb-0.1.12

### DIFF
--- a/src/LibUsb.cpp
+++ b/src/LibUsb.cpp
@@ -521,12 +521,12 @@ int LibUsb::write(uint8_t *buf, int bytes)
 
     int rc;
     if (OperatingSystem == WINDOWS) {
-        rc = usb_interrupt_write(device, writeEndpoint, (const char *)buf, bytes, 1000);
+        rc = usb_interrupt_write(device, writeEndpoint, (char *)buf, bytes, 1000);
     } else {
         // we use a non-interrupted write on Linux/Mac since the interrupt
         // write block size is incorrectly implemented in the version of
         // libusb we build with. It is no less efficient.
-        rc = usb_bulk_write(device, writeEndpoint, (const char *)buf, bytes, 125);
+        rc = usb_bulk_write(device, writeEndpoint, (char *)buf, bytes, 125);
     }
 
     if (rc < 0)

--- a/src/LibUsb.h
+++ b/src/LibUsb.h
@@ -31,6 +31,7 @@
 #elif defined GC_HAVE_LIBUSB
 #include <usb.h> // for the constants etc
 #include <errno.h>
+#include <stdint.h>
 const int LIBUSB_ERROR_IO = -EIO;
 const int LIBUSB_ERROR_TIMEOUT = -ETIMEDOUT;
 const int LIBUSB_ERROR_PIPE = -EPIPE;


### PR DESCRIPTION
When using gcconfig to use the old libusb (libusb-0.1.12 as packaged with GC) by using the LIBUSB_INSTALL setting (instead of LIBUSB1_INSTALL for libusb-1.0.18+), I'm getting compilation errors.

You might want to try the same, and if you get errors, merge in this pull request to fix them.

To be exact. I build using libusb-1.0.18+ by setting and using LIBUSB1_INSTALL. The build is successful. I then disable (by commenting out) LIBUSB1_INSTALL, and enable libusb-0.1.12 by setting LIBUSB_INSTALL, doing a "make clean; qmake; make" and the build fails. These changes resolve this.

Let me know how it goes for you.
