### PR TITLE
fix builds for libusb-0.1.12

### DIFF
--- a/src/LibUsb.cpp
+++ b/src/LibUsb.cpp
@@ -521,12 +521,12 @@ int LibUsb::write(uint8_t *buf, int bytes)
 
     int rc;
     if (OperatingSystem == WINDOWS) {
-        rc = usb_interrupt_write(device, writeEndpoint, (const char *)buf, bytes, 1000);
+        rc = usb_interrupt_write(device, writeEndpoint, (char *)buf, bytes, 1000);
     } else {
         // we use a non-interrupted write on Linux/Mac since the interrupt
         // write block size is incorrectly implemented in the version of
         // libusb we build with. It is no less efficient.
-        rc = usb_bulk_write(device, writeEndpoint, (const char *)buf, bytes, 125);
+        rc = usb_bulk_write(device, writeEndpoint, (char *)buf, bytes, 125);
     }
 
     if (rc < 0)

--- a/src/LibUsb.h
+++ b/src/LibUsb.h
@@ -31,6 +31,7 @@
 #elif defined GC_HAVE_LIBUSB
 #include <usb.h> // for the constants etc
 #include <errno.h>
+#include <stdint.h>
 const int LIBUSB_ERROR_IO = -EIO;
 const int LIBUSB_ERROR_TIMEOUT = -ETIMEDOUT;
 const int LIBUSB_ERROR_PIPE = -EPIPE;


### PR DESCRIPTION
When building GC with the old libusb-0.1.12 enabled (enabling LIBUSB_INSTALL instead of LIBUSB1-INSTALL, the build fails in 2 places. This pull requested resolves those.

You may want to build with the old libusb-0.1.12 installed and verify the errors happen on your system, though I've attempted building on 2 different computers and get the same errors.
